### PR TITLE
Check midje-nrepl version on startup

### DIFF
--- a/elisp/emidje.el
+++ b/elisp/emidje.el
@@ -152,11 +152,14 @@ Shows warning messages on Cider's REPL when applicable."
       (emidje-show-warning-on-repl "midje-nrepl isn't in your classpath; Emidje keybindings won't work.
  You can either start this REPL via cider-jack-in or add midje-nrepl to your profile.clj dependencies."))
      ((not (string-equal emidje-version midje-nrepl-version))
-      (emidje-show-warning-on-repl "Emidje and midje-nrepl are out of sync (things will break).
+      (emidje-show-warning-on-repl "Emidje and midje-nrepl are out of sync. Things will break!
 Their versions are %s and %s, respectively.
 Please, consider updating the midje-nrepl version in your profile.clj to %s or start the REPL via cider-jack-in." emidje-version midje-nrepl-version emidje-version)))))
 
 (defun emidje-inject-jack-in-dependencies ()
+  "Adds midje-nrepl to the Cider's list of Lein plugins.
+The midje-nrepl's version is inferred by calling emidje-package-version.
+Therefore, when the REPL is open via cider-jack-in, Emidje's version and midje-nrepl's version will be in sync."
   (add-to-list 'cider-jack-in-lein-plugins `("midje-nrepl" ,(emidje-package-version)) t))
 
 ;;;###autoload

--- a/elisp/emidje.el
+++ b/elisp/emidje.el
@@ -5,7 +5,7 @@
 ;; Version: 0.1.0-SNAPSHOT
 ;; Package-Requires: ((cider "0.17.0"))
 ;; Homepage: https://github.com/alan-ghelardi/emidje
-;; Keywords: Cider, Clojure, tests
+;; Keywords: Cider, Clojure, Midje, tests
 
 ;;; Commentary:
 


### PR DESCRIPTION
As of this pull request Emidje will check the midje-nrepl's version on startup, by printing a warning message to the
user when applicable. Also, midje-nrepl's version now is inferred from the Emidje's version instead of being hardcoded.