### PR TITLE
Read version properly and fix lint error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Do not set markers after rendering the test report buffer.
+- Get Emidje's version properly when the package has been installed from Melpa.
 
 ## [1.0.0] - 2018-11-13
 

--- a/emidje.el
+++ b/emidje.el
@@ -25,6 +25,7 @@
 (ignore-errors
   ;; For cider >= 0.18.x
   (require 'cider-format))
+(require 'pkg-info)
 (require 'seq)
 
 (defface emidje-failure
@@ -155,12 +156,12 @@ is returned."
         (emidje-handle-nrepl-response #'identity)))))
 
 (defun emidje-version ()
-  "Get Emidje's current version from the package header."
-  (let ((version-regex "^\\([0-9]+\.[0-9]+\.[0-9]+\\)\\(.+\\)$")
-        (version (car (split-string (pkg-info-version-info 'emidje)))))
+  "Read Emidje's version from the version header."
+  (let ((version-regex "^[0-9]+\.[0-9]+\.[0-9]+-?[A-Z0-9]*$")
+        (version (lm-version (pkg-info-library-source 'emidje))))
     (if (not (string-match version-regex version))
-        version
-      (concat (match-string 1 version) "-" (upcase (match-string 2 version))))))
+        (error "Invalid version `%s'" version)
+      version)))
 
 (defun emidje-show-warning-on-repl (message &rest args)
   "Show the MESSAGE on the Cider's REPL buffer if applicable.

--- a/emidje.el
+++ b/emidje.el
@@ -22,9 +22,10 @@
 
 (require 'ansi-color)
 (require 'cider)
-(ignore-errors
+(unless (fboundp 'cider--format-region)
   ;; For cider >= 0.18.x
-  (require 'cider-format))
+  (require 'cider-format)
+  (declare-function cider--format-region "cider-format" (start end formatter)))
 (require 'pkg-info)
 (require 'seq)
 

--- a/test/emidje-nrepl-middleware-injection-and-startup-stuff-tests.el
+++ b/test/emidje-nrepl-middleware-injection-and-startup-stuff-tests.el
@@ -16,15 +16,29 @@
 (require 'emidje-test-helpers)
 
 (describe "When I call `emidje-version'"
+          (let ((source "/home/john-doe/.emacs.d/elpa/emidje-2a57c2b/emidje.el"))
 
-          (it "returns the Emidje's current version"
-              (spy-on 'pkg-info-version-info :and-return-value "1.0.1 5cfc262")
-              (expect (emidje-version) :to-equal "1.0.1")
-              (expect 'pkg-info-version-info :to-have-been-called-with 'emidje))
+            (it "returns the version defined in emidje.el"
+                (spy-on 'pkg-info-library-source :and-return-value source)
+                (spy-on 'lm-version :and-return-value "1.0.1")
+                (expect (emidje-version) :to-equal "1.0.1")
+                (expect 'pkg-info-library-source :to-have-been-called-with 'emidje)
+                (expect 'lm-version :to-have-been-called-with source))
 
-          (it "also treats versions with qualifiers in a proper way"
-              (spy-on 'pkg-info-version-info :and-return-value "1.0.1alpha 5cfc262")
-              (expect (emidje-version) :to-equal "1.0.1-ALPHA")))
+            (it "treats versions with qualifiers properly"
+                (spy-on 'pkg-info-library-source :and-return-value source)
+                (spy-on 'lm-version :and-return-value "1.0.1-SNAPSHOT")
+                (expect (emidje-version) :to-equal "1.0.1-SNAPSHOT")
+                (expect 'pkg-info-library-source :to-have-been-called-with 'emidje)
+                (expect 'lm-version :to-have-been-called-with source))
+
+            (it "throws an error when the version was mistakenly declared"
+                (spy-on 'pkg-info-library-source :and-return-value source)
+                (spy-on 'lm-version :and-return-value "1.0")
+                (expect (emidje-version) :to-throw 'error))
+
+            (it "validates that the current version was declared properly"
+                (expect (emidje-version) :not :to-throw))))
 
 (describe "When I call `emidje-show-warning-on-repl'"
           (before-each


### PR DESCRIPTION
As of this pull request Emidje obtains its own version through a combination of
`pkg-info-library-source` and `lm-version`, what ensures that the version
declared in the `Version` header will be read when the package is installed from
Melpa. In addition, the error `cider--format-region might not be defined in
runtime` raised by elisp-lint was fixed.