### PR TITLE
Fix build on CircleCI and remove eval-after-load from emidje-setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Support for running builds on [CircleCI](https://circleci.com/).
-- A set of unit tests through [Buttercup](https://github.com/jorgenschaefer/emacs-buttercup).
+- A set of unit tests through
+  [Buttercup](https://github.com/jorgenschaefer/emacs-buttercup).
+
+### Changed
+- Do not call `emidje-enable-nrepl-middleware` inside `eval-after-load`. From
+  now on users will be responsible for calling `emidje-setup` after Cider.
 
 ### Fixed
 - Do not set markers after rendering the test report buffer.

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ lint: install
 		--eval "(progn (require 'package) \
 			(push '(\"melpa\" . \"http://melpa.org/packages/\") package-archives) \
 			(package-initialize))" \
+	--eval '(package-refresh-contents)' \
 	-l package-lint.el \
 	-f package-lint-batch-and-exit \
 	$(linting_files)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ order to enable the automatic injection of the nREPL middleware and activate the
 switch to the `Cider's REPL` buffer:
 
 ```el
-(emidje-setup)
+(eval-after-load 'cider
+  #'emidje-setup)
 ```
 
 Alternatively, you can write your own function to add `emidje-mode` to the

--- a/emidje.el
+++ b/emidje.el
@@ -664,8 +664,7 @@ enable the mode if ARG is omitted or nil.
 ;;;###autoload
 (defun emidje-setup ()
   "Setup `emidje-mode' and enable the `midje-nrepl' middleware conveniently."
-  (eval-after-load 'cider
-    #'emidje-enable-nrepl-middleware)
+  (emidje-enable-nrepl-middleware)
   (add-hook 'clojure-mode-hook #'emidje-mode t)
   (add-hook 'cider-repl-mode-hook #'emidje-mode t))
 


### PR DESCRIPTION
Fix lint task to run properly on CircleCI and remove the `eval-after-load` from the `emidje-setup` function. From now on users must be responsible for calling `emidje-setup` after loading Cider.