### PR TITLE
Allow for users to select the test path where tests will be run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Allow for users to select the test path where tests will be run, by calling
+  `emidje-run-all-tests` with a prefix argument.
+
 ## [1.0.1] - 2018-12-05
 
 ### Added
@@ -21,7 +25,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 - Do not set markers after rendering the test report buffer.
 - Get Emidje's version properly when the package has been installed from Melpa.
-- Show proper descriptions for failing tabular facts by upgrading to the latest version of [midje-nrepl].
+- Show proper descriptions for failing tabular facts by upgrading to the latest
+  version of [midje-nrepl].
 
 ## [1.0.0] - 2018-11-13
 

--- a/emidje.el
+++ b/emidje.el
@@ -449,9 +449,10 @@ parameters to be sent to nREPL middleware."
   "Run facts defined in all project namespaces.
 When called interactively with a prefix argument
 SELECT-TEST-PATH, prompt the user for selecting a test path."
-  (interactive "p")
-  (let ((test-paths (when select-test-path (list (emidje-select-test-path)))))
-    (emidje-send-test-request :project `(test-paths ,test-paths))))
+  (interactive "P")
+  (let ((request (when select-test-path
+                   `(test-paths (,(emidje-select-test-path))))))
+    (emidje-send-test-request :project request)))
 
 (defun emidje-current-test-ns ()
   "Return the test namespace that corresponds to the current Clojure namespace context."

--- a/emidje.el
+++ b/emidje.el
@@ -442,13 +442,13 @@ parameters to be sent to nREPL middleware."
 (defun emidje-select-test-path ()
   "Prompt user for selecting a test path."
   (let ((test-paths (nrepl-dict-get (emidje-send-request :test-paths) "test-paths")))
-    (ido-completing-read "Select a test path:"
-                         test-paths)))
+    (ido-completing-read "Select a test path: "
+                         test-paths nil t)))
 
 (defun emidje-run-all-tests (&optional select-test-path)
   "Run facts defined in all project namespaces.
 When called interactively with a prefix argument
-SELECT-TEST-PATH, prompt the user for selecting a test path."
+SELECT-TEST-PATH, prompts the user for selecting a test path."
   (interactive "P")
   (let ((request (when select-test-path
                    `(test-paths (,(emidje-select-test-path))))))

--- a/test/emidje-run-facts-and-show-reports-tests.el
+++ b/test/emidje-run-facts-and-show-reports-tests.el
@@ -442,7 +442,8 @@ Checker said about the reason: This is a message")))
                         (expect 'emidje-send-request :to-have-been-called-with :test-paths))
 
                     (it "calls `ido-completing-read' with the expected arguments"
-                        (expect 'ido-completing-read :to-have-been-called-with "Select a test path:" (list "integration" "test"))))
+                        (expect 'ido-completing-read :to-have-been-called-with "Select a test path: " (list "integration" "test")
+                                nil t)))
 
           )
 

--- a/test/emidje-run-facts-and-show-reports-tests.el
+++ b/test/emidje-run-facts-and-show-reports-tests.el
@@ -382,7 +382,7 @@ takes a number x and returns its square root"))))
 
           (it "calls `emidje-send-request' with the correct arguments"
               (expect emidje-tests-op-alias :to-equal :project)
-              (expect emidje-tests-sent-request :to-equal `(test-paths nil)))
+              (expect emidje-tests-sent-request :to-be nil))
 
           (it "shows a message in the echo area by saying that tests are being run"
               (expect (emidje-tests-last-displayed-message 2)
@@ -427,6 +427,24 @@ expected: :green\t\s\s
   actual: :orange\t\s\s
 
 Checker said about the reason: This is a message")))
+
+(describe "When I call `emidje-select-test-path'"
+
+          (describe "and the project has more than one test path set"
+                    (before-each
+                     (spy-on 'emidje-send-request :and-return-value (nrepl-dict
+                                                                     "status" (list "done")
+                                                                     "test-paths" (list "integration" "test")))
+                     (spy-on 'ido-completing-read :and-return-value "test")
+                     (emidje-select-test-path))
+
+                    (it "calls `emidje-send-request' with the expected arguments"
+                        (expect 'emidje-send-request :to-have-been-called-with :test-paths))
+
+                    (it "calls `ido-completing-read' with the expected arguments"
+                        (expect 'ido-completing-read :to-have-been-called-with "Select a test path:" (list "integration" "test"))))
+
+          )
 
 (describe "When I call `emidje-run-all-tests' with a prefix argument"
           (before-each


### PR DESCRIPTION
As of this pull request, when one calls `emidje-run-all-tests` with a prefix
argument, Emidje shows an Ido choice list with the known test paths for the
project. So, users can run facts for a specific test path (e.g. only integration
tests when those are separated in a different test folder).