### PR TITLE
Add support for namespace filters and include Magit popup menu

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -8,6 +8,7 @@
                    (elisp-lint-indent-specs . ((cider-propertize-region . 1)
                                                (cl-flet . 1)
                                                (if-let . 2)
+                                               (magit-define-popup . 1)
                                                (nrepl-dbind-response . 2)
                                                (thread-first . 1)
                                                (thread-last . 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   and/or include namespaces to be tested. Those options can be set through the
   aforementioned popup.
 
+### Changed
+- `emidje-run-all-tests` (`c-c c-j p`) can't be called with a prefix argument
+  anymore to select test paths. Instead, users should use `c-c c-j P` to set
+  this option (and others) via a Magit popup menu.
+
 ## [1.1.0] - 2018-12-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- [15](https://github.com/nubank/emidje/pull/15): add the command
+  `emidje-run-all-tests-popup`, bound to `c-c c-j P`. This keybinding shows a
+  Magit popup that allow for users to set some switches/options to customize the
+  test execution.
+- [15](https://github.com/nubank/emidje/pull/15): add ns filters to exclude
+  and/or include namespaces to be tested. Those options can be set through the
+  aforementioned popup.
+
 ## [1.1.0] - 2018-12-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- [15](https://github.com/nubank/emidje/pull/15): add the command
+- [#15](https://github.com/nubank/emidje/pull/15): add the command
   `emidje-run-all-tests-popup`, bound to `c-c c-j P`. This keybinding shows a
   Magit popup that allow for users to set some switches/options to customize the
   test execution.
-- [15](https://github.com/nubank/emidje/pull/15): add ns filters to exclude
+- [#15](https://github.com/nubank/emidje/pull/15): add ns filters to exclude
   and/or include namespaces to be tested. Those options can be set through the
   aforementioned popup.
 

--- a/emidje.el
+++ b/emidje.el
@@ -440,12 +440,18 @@ parameters to be sent to nREPL middleware."
                              (emidje-echo-test-summary op-alias (plist-get message 'ns) summary)
                              (emidje-render-test-report results summary))))))
 
-(defun emidje-select-test-path (_ __)
+(defun emidje-select-test-path (_ value)
   "Prompt user for selecting a test path.
-This function is meant to be used in Magit popups (for more details see `magit-define-popup-option')."
-  (let ((test-paths (nrepl-dict-get (emidje-send-request :test-paths) "test-paths")))
-    (list (ido-completing-read "Select a test path: "
-                               test-paths nil t))))
+This function is meant to be used in Magit popups (for more
+details see `magit-define-popup-option').  VALUE is a list
+containing the current selected test paths or nil if none is
+selected."
+  (let* ((test-paths (nrepl-dict-get (emidje-send-request :test-paths) "test-paths"))
+         (selected-path (ido-completing-read "Select a test path: "
+                                             test-paths nil t)))
+    (if value
+        (cons selected-path value)
+      (list selected-path))))
 
 (defun emidje-parse-popup-args (args)
   "Parse Magit popup arguments and convert them to a list.

--- a/emidje.el
+++ b/emidje.el
@@ -4,7 +4,7 @@
 
 ;; Author: Alan Ghelardi <alan.ghelardi@nubank.com.br>
 ;; Maintainer: Alan Ghelardi <alan.ghelardi@nubank.com.br>
-;; Version: 1.1.1-SNAPSHOT
+;; Version: 1.2.0-SNAPSHOT
 ;; Package-Requires: ((emacs "25") (cider "0.17.0") (seq "2.16"))
 ;; Homepage: https://github.com/nubank/emidje
 ;; Keywords: tools
@@ -439,20 +439,53 @@ parameters to be sent to nREPL middleware."
                              (emidje-echo-test-summary op-alias (plist-get message 'ns) summary)
                              (emidje-render-test-report results summary))))))
 
-(defun emidje-select-test-path ()
-  "Prompt user for selecting a test path."
+(defun emidje-select-test-path (_ value)
+  "Prompt user for selecting a test path.
+This function is meant to be used in Magit popups (for more details see `magit-define-popup-option')."
   (let ((test-paths (nrepl-dict-get (emidje-send-request :test-paths) "test-paths")))
-    (ido-completing-read "Select a test path: "
-                         test-paths nil t)))
+    (list (ido-completing-read "Select a test path: "
+                               test-paths nil t))))
 
-(defun emidje-run-all-tests (&optional select-test-path)
+(defun emidje-parse-popup-args (args)
+  "Parse Magit popup arguments and convert them to a list.
+ARGS is a list containing options and/or switches produced by
+`magit-define-popup'. Returns a list of key and values that can
+be sent as request parameters to nREPL."
+  (cl-flet* ((parse-switch (switch-name)
+                           (list switch-name "true" ))
+             (parse-value (value)
+                          (let ((value (car (read-from-string value))))
+                            (if (symbolp value)
+                                (symbol-name value)
+                              (seq-map #'symbol-name value))))
+             (parse-option (option-name value)
+                           (list option-name
+                                 (parse-value value)))
+             (parse-arg (arg)
+                        (let ((parts (split-string arg "=")))
+                          (if (= (length parts) 1)
+                              (parse-switch (car parts))
+                            (parse-option (car parts) (car (cdr parts)))))))
+    (seq-reduce (lambda (results arg)
+                  (seq-concatenate 'list results (parse-arg arg)))
+                args (list))))
+
+(defun emidje-run-all-tests (&optional args)
   "Run facts defined in all project namespaces.
 When called interactively with a prefix argument
 SELECT-TEST-PATH, prompts the user for selecting a test path."
-  (interactive "P")
-  (let ((request (when select-test-path
-                   `(test-paths (,(emidje-select-test-path))))))
-    (emidje-send-test-request :project request)))
+  (interactive (list (emidje-parse-popup-args (emidje-run-all-tests-arguments))))
+  (emidje-send-test-request :project args))
+
+(magit-define-popup emidje-run-all-tests-popup
+  "Popup console for `emidje-run-all-tests' command."
+  :options
+  '("Options for filtering tests"
+    (?e "Regex to exclude namespaces" "exclusions=")
+    (?i "Regex to include namespaces" "inclusions=")
+    (?t "Limit test paths" "test-paths="  emidje-select-test-path))
+  :actions
+  '((?R "Run tests" emidje-run-all-tests())))
 
 (defun emidje-current-test-ns ()
   "Return the test namespace that corresponds to the current Clojure namespace context."
@@ -668,6 +701,7 @@ If called interactively with the prefix argument `OTHER-WINDOW', visit the file 
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-j f") #'emidje-format-tabular)
     (define-key map (kbd "C-c C-j p") #'emidje-run-all-tests)
+    (define-key map (kbd "C-c C-j P") #'emidje-run-all-tests-popup)
     (define-key map (kbd "C-c C-j n") #'emidje-run-ns-tests)
     (define-key map (kbd "C-c C-j t") #'emidje-run-test-at-point)
     (define-key map (kbd "C-c C-j r") #'emidje-re-run-non-passing-tests)

--- a/test/emidje-run-facts-and-show-reports-tests.el
+++ b/test/emidje-run-facts-and-show-reports-tests.el
@@ -508,9 +508,11 @@ Checker said about the reason: This is a message")))
           to nREPL"
               (expect (emidje-parse-popup-args `("coverage?"
                                                  "ns-exclusions=(too-slow-test colors-test)"
+                                                 "ns-inclusions=(^adapters?)"
                                                  "top-slowest-tests=5"))
                       :to-equal `(coverage? "true"
                                             ns-exclusions ("too-slow-test" "colors-test")
+                                            ns-inclusions ("^adapters?")
                                             top-slowest-tests 5))))
 
 (describe "When I call `emidje-run-all-tests' interactively with


### PR DESCRIPTION
This pull request depends on [this
one](https://github.com/nubank/midje-nrepl/pull/12) on `midje-nrepl`.

From now on when users call `c-c c-j P`, Emidje shows a Magit popup menu with
some switches/options to send additional parameters to the nREPL
middleware. Currently, the following options are supported:
* test-paths: allow for users to restrict the test execution to a known test
directory.
* ns-exclusions: a list of regexes to remove namespaces from the list of tested
  ones.
  * ns-inclusions: same as ns-exclusions, but allow for users to include namespaces.