### PR TITLE
Add white space in the minor mode's lighter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   related information are grouped in outline sections that may be expanded or
   collapsed.
 
+### Fixed
+- [#18](https://github.com/nubank/emidje/pull/18): avoid concatenating the minor
+  mode's title with other minor modes by adding a white space in the beginning
+  of the lighter.
+
 ## [1.1.0] - 2018-12-19
 
 ### Added

--- a/emidje.el
+++ b/emidje.el
@@ -841,7 +841,7 @@ is positive, and disable it otherwise.  If called from Lisp,
 enable the mode if ARG is omitted or nil.
 
 \\{emidje-commands-map}"
-  :lighter "emidje"
+  :lighter " emidje"
   :keymap emidje-commands-map)
 
 ;;;###autoload


### PR DESCRIPTION
This will avoid concatenating the minor mode's title with other minor modes.