### PR TITLE
Fix conditional injection of the nREPL middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [#18](https://github.com/nubank/emidje/pull/18): avoid concatenating the minor
   mode's title with other minor modes by adding a white space in the beginning
   of the lighter.
+  - [#20](https://github.com/nubank/emidje/pull/20): fix logic to determine
+    whether the nREPL middleware should be injected in the REPL at Cider
+    jack-in.
 
 ## [1.1.0] - 2018-12-19
 

--- a/emidje.el
+++ b/emidje.el
@@ -210,11 +210,18 @@ Show warning messages on Cider's REPL when applicable."
 Their versions are %s and %s, respectively.
 Please, consider updating the midje-nrepl version in your profile.clj to %s or start the REPL via cider-jack-in." emidje-version midje-nrepl-version emidje-version)))))
 
+(defun emidje-inject-nrepl-middleware-p (&rest _)
+  "Return t if the nREPL middleware should be injected at Cider jack-in.
+Currently, this predicate returns the value of
+  `emidje-inject-nrepl-middleware-at-jack-in'.  For more details
+  about predicate functions called by Cider at jack-in, see
+  `cider-jack-in-lein-plugins'."
+  emidje-inject-nrepl-middleware-at-jack-in)
+
 (defun emidje-inject-nrepl-middleware ()
   "Inject `midje-nrepl' in the REPL started by `cider-jack-in'."
-  (when (and (boundp 'cider-jack-in-lein-plugins)
-             emidje-inject-nrepl-middleware-at-jack-in)
-    (add-to-list 'cider-jack-in-lein-plugins `("nubank/midje-nrepl" ,(emidje-version)) t)))
+  (when (boundp 'cider-jack-in-lein-plugins)
+    (add-to-list 'cider-jack-in-lein-plugins `("nubank/midje-nrepl" ,(emidje-version)  :predicate emidje-inject-nrepl-middleware-p) t)))
 
 ;;;###autoload
 (defun emidje-enable-nrepl-middleware ()

--- a/test/emidje-nrepl-middleware-injection-and-startup-stuff-tests.el
+++ b/test/emidje-nrepl-middleware-injection-and-startup-stuff-tests.el
@@ -117,19 +117,29 @@ Please, consider updating the midje-nrepl version in your profile.clj to %s or s
               (emidje-enable-nrepl-middleware)
               (expect cider-connected-hook :to-contain #'emidje-check-nrepl-middleware-version))
 
+          (it "adds `midje-nrepl' to the list of Leiningen plugins injected by Cider at jack-in"
+              (spy-on 'emidje-version :and-return-value "1.0.1")
+              (emidje-enable-nrepl-middleware)
+              (expect cider-jack-in-lein-plugins :to-contain `("nubank/midje-nrepl" "1.0.1" :predicate emidje-inject-nrepl-middleware-p)))
+
           (describe "and `emidje-inject-nrepl-middleware-at-jack-in' is set to t"
                     (before-all
                      (setq-local emidje-inject-nrepl-middleware-at-jack-in t))
 
-                    (it "adds `midje-nrepl' to the list of Leiningen plugins injected by Cider at jack-in"
-                        (spy-on 'emidje-version :and-return-value "1.0.1")
+                    (it "the predicate function returns t"
                         (emidje-enable-nrepl-middleware)
-                        (expect cider-jack-in-lein-plugins :to-contain `("nubank/midje-nrepl" "1.0.1"))))
+                        (expect (thread-first cider-jack-in-lein-plugins
+                                  car
+                                  (plist-get :predicate)
+                                  (apply (list nil))) :to-be t)))
 
           (describe "and `emidje-inject-nrepl-middleware-at-jack-in' is set to nil"
                     (before-all
                      (setq-local emidje-inject-nrepl-middleware-at-jack-in nil))
 
-                    (it "doesn't add `midje-nrepl' to the list of Leiningen plugins injected by Cider at jack-in"
+                    (it "the predicate function returns nil"
                         (emidje-enable-nrepl-middleware)
-                        (expect cider-jack-in-lein-plugins :to-be nil))))
+                        (expect (thread-first cider-jack-in-lein-plugins
+                                  car
+                                  (plist-get :predicate)
+                                  (apply (list nil))) :to-be nil))))


### PR DESCRIPTION
There was a mistake in the previous implementation and the variable
`emidje-inject-nrepl-middleware-at-jack-in` was pointless to determine whether
the middleware should be injected. With this fix users can set this variable on
demand to avoid injecting the nREPL middleware in the REPL.